### PR TITLE
hardware/gpio: Add gpio_get_dir() and gpio_get_pull() accessors.

### DIFF
--- a/src/bao1x/hardware_gpio/gpio.c
+++ b/src/bao1x/hardware_gpio/gpio.c
@@ -224,3 +224,16 @@ void gpio_set_dir_masked(uint port, uint32_t mask)
     volatile uint32_t *reg = s_gpiooe_reg(port);
     *reg = mask;
 }
+
+/** @brief Return true if a pin is configured as output.
+ *  @param[in] port GPIO port (0-5).
+ *  @param[in] pin  Pin number within port (0-15).
+ *  @return true if pin is output, false if input.
+ *  @req REQ-DABAO-GPIO-0013 */
+bool gpio_get_dir(uint port, uint pin)
+{
+    SEVS_ASSERT(port < GPIO_NUM_PORTS);
+    SEVS_ASSERT(pin <= GPIO_MAX_PIN);
+    volatile uint32_t *reg = s_gpiooe_reg(port);
+    return (*reg >> pin) & 1;
+}

--- a/src/bao1x/hardware_gpio/gpio.c
+++ b/src/bao1x/hardware_gpio/gpio.c
@@ -175,6 +175,19 @@ void gpio_disable_pulls(uint port, uint pin)
     *reg &= ~(1 << pin);
 }
 
+/** @brief Return true if the pull-up resistor is enabled.
+ *  @param[in] port GPIO port (0-5).
+ *  @param[in] pin  Pin number within port (0-15).
+ *  @return true if pull-up is enabled, false otherwise.
+ *  @req REQ-DABAO-GPIO-0014 */
+bool gpio_get_pull(uint port, uint pin)
+{
+    SEVS_ASSERT(port < GPIO_NUM_PORTS);
+    SEVS_ASSERT(pin <= GPIO_MAX_PIN);
+    volatile uint32_t *reg = s_gpiopu_reg(port);
+    return (*reg >> pin) & 1;
+}
+
 /** @brief Enable or disable the Schmitt trigger on a pin.
  *  @param[in] port   GPIO port (0-5).
  *  @param[in] pin    Pin number within port (0-15).

--- a/src/bao1x/hardware_gpio/include/hardware/gpio.h
+++ b/src/bao1x/hardware_gpio/include/hardware/gpio.h
@@ -65,6 +65,9 @@ void gpio_pull_up(uint port, uint pin);
 /* Disable the pull-up resistor. */
 void gpio_disable_pulls(uint port, uint pin);
 
+/* Return true if the internal pull-up resistor is enabled. */
+bool gpio_get_pull(uint port, uint pin);
+
 /* Enable or disable the Schmitt trigger on an input pin. */
 void gpio_set_schmitt(uint port, uint pin, bool enable);
 

--- a/src/bao1x/hardware_gpio/include/hardware/gpio.h
+++ b/src/bao1x/hardware_gpio/include/hardware/gpio.h
@@ -77,6 +77,9 @@ uint32_t gpio_get_all(uint port);
 /* Set output direction for multiple pins using a bitmask. 1 = output. */
 void gpio_set_dir_masked(uint port, uint32_t mask);
 
+/* Return true if the pin is currently configured as output. */
+bool gpio_get_dir(uint port, uint pin);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Hello! Thanks for building this SDK, I'm quite excited about the bauchip. While I am interested in learning more about embedded rust, I'm also really keen to use it with existing platforms, my favourite one being micropython. 

I've started putting together a micropython port on this and must say congrats - the quality and stability I've seen so far of this SDK is outstanding, my port has come together very smoothly.

This PR simply adds two read-back helpers that are needed for full pin state introducing in MicroPython:

- `gpio_get_dir(port, pin)` - reads the GPIOOE register bit and returns true if the pin is currently configured as output.
- `gpio_get_pull(port, pin)` - reads the pull-up configuration register and returns true if the internal pull-up is enabled.

Tested with my MicroPython baochip port on the Dabao eval board, where these are used to implement `Pin.__repr__()` and `Pin.init(mode=None, pull=...)` without full reconfiguration.

Disclosure: I'm using LLM's in my development and testing practice, I hope that this is ok within your repo here.