### PR TITLE
Add pure25519 doc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ chmod +x bao_flash.sh
 
 - **Python 3:** Required for UF2 signing and serial flashing
 - **pyserial:** `pip install pyserial`
+- **pure25519:** `pip install pure25519`
 - **USB-serial adapter:** PB14 (TX), PB13 (RX), 115200 baud for serial output
 
 ### Toolchain Setup


### PR DESCRIPTION
Thanks for the SDK! Doing a little testing of it, if you don't mind I may make a couple PR's to help improve the getting started experience...

The pure25519 dependency is missing from the python requirements, so the quickstart doesn't quite build, it fails like this:

```
.\bao_flash.bat build blink
Using RISC-V toolchain from PATH.

============================================
============================================

[1/4] Assembling startup ...
[2/4] Compiling SDK ...
[3/4] Compiling blink ...
[4/4] Linking blink.uf2 ...
Traceback (most recent call last):
  File "F:\code\dabao-sdk\tools\sign_and_uf2.py", line 40, in <module>
    from pure25519.basic import bytes_to_clamped_scalar, scalar_to_bytes, Base
ModuleNotFoundError: No module named 'pure25519'

*** FAILED ***
```

Adding the requirement fixes this issue.